### PR TITLE
Update ldbc schema for katana to match the ldbc spec

### DIFF
--- a/csv_datasets/ldbc/lists/edges-sf-003-full-parquet.txt
+++ b/csv_datasets/ldbc/lists/edges-sf-003-full-parquet.txt
@@ -38,7 +38,7 @@ creationDate:IGNORE|:START_ID(Forum)|:END_ID(Post)
 sf-003/parquet/9/part.0.parquet
 sf-003/parquet/9/part.1.parquet
 
-creationDate:IGNORE|:START_ID(Forum)|:END_ID(Person)
+creationDate:DATETIME|:START_ID(Forum)|:END_ID(Person)
 sf-003/parquet/10/part.0.parquet
 sf-003/parquet/10/part.1.parquet
 
@@ -63,12 +63,12 @@ sf-003/parquet/15/part.0.parquet
 sf-003/parquet/15/part.1.parquet
 
 KATANA_DEFAULT_LABEL=KNOWS
-creationDate:IGNORE|:START_ID(Person)|:END_ID(Person)
+creationDate:DATETIME|:START_ID(Person)|:END_ID(Person)
 sf-003/parquet/16/part.0.parquet
 sf-003/parquet/16/part.1.parquet
 
 KATANA_DEFAULT_LABEL=
-creationDate:IGNORE|:START_ID(Person)|:END_ID(Post)
+creationDate:DATETIME|:START_ID(Person)|:END_ID(Post)
 sf-003/parquet/21/part.0.parquet
 sf-003/parquet/21/part.1.parquet
 

--- a/csv_datasets/ldbc/lists/edges-sf-003-full-without-types.txt
+++ b/csv_datasets/ldbc/lists/edges-sf-003-full-without-types.txt
@@ -14,27 +14,27 @@ sf-003/static/tag_hasType_tagclass/part-00000-0e79b266-fdeb-45c9-bc07-0df894854d
 sf-003/static/tagclass_isSubclassOf_tagclass/part-00000-3a05ed0e-440f-4389-bdd2-7ecabccdedc7-c000.csv.split_0
 sf-003/static/tagclass_isSubclassOf_tagclass/part-00000-3a05ed0e-440f-4389-bdd2-7ecabccdedc7-c000.csv.split_1
 
-creationDate|:START_ID(Comment)|:END_ID(Person)|:TYPE
+:IGNORE|:START_ID(Comment)|:END_ID(Person)|:TYPE
 sf-003/dynamic/comment_hasCreator_person/part-00000-6fabcea1-6ec8-4944-a25d-c8af3a1810fd-c000.csv.split_0
 sf-003/dynamic/comment_hasCreator_person/part-00000-6fabcea1-6ec8-4944-a25d-c8af3a1810fd-c000.csv.split_1
 
-creationDate|:START_ID(Comment)|:END_ID(Tag)|:TYPE
+:IGNORE|:START_ID(Comment)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/comment_hasTag_tag/part-00000-17cded5e-b442-4075-97c9-51eb700574b5-c000.csv.split_0
 sf-003/dynamic/comment_hasTag_tag/part-00000-17cded5e-b442-4075-97c9-51eb700574b5-c000.csv.split_1
 
-creationDate|:START_ID(Comment)|:END_ID(Place)|:TYPE
+:IGNORE|:START_ID(Comment)|:END_ID(Place)|:TYPE
 sf-003/dynamic/comment_isLocatedIn_place/part-00000-b73c3da6-ab3b-4cc1-b5c1-39914cbb9f71-c000.csv.split_0
 sf-003/dynamic/comment_isLocatedIn_place/part-00000-b73c3da6-ab3b-4cc1-b5c1-39914cbb9f71-c000.csv.split_1
 
-creationDate|:START_ID(Comment)|:END_ID(Comment)|:TYPE
+:IGNORE|:START_ID(Comment)|:END_ID(Comment)|:TYPE
 sf-003/dynamic/comment_replyOf_comment/part-00000-72df4522-f48d-424c-9d01-11bfe0bc7cea-c000.csv.split_0
 sf-003/dynamic/comment_replyOf_comment/part-00000-72df4522-f48d-424c-9d01-11bfe0bc7cea-c000.csv.split_1
 
-creationDate|:START_ID(Comment)|:END_ID(Post)|:TYPE
+:IGNORE|:START_ID(Comment)|:END_ID(Post)|:TYPE
 sf-003/dynamic/comment_replyOf_post/part-00000-6bee34cb-0e59-454b-a96f-01bb8c448f42-c000.csv.split_0
 sf-003/dynamic/comment_replyOf_post/part-00000-6bee34cb-0e59-454b-a96f-01bb8c448f42-c000.csv.split_1
 
-creationDate|:START_ID(Forum)|:END_ID(Post)|:TYPE
+:IGNORE|:START_ID(Forum)|:END_ID(Post)|:TYPE
 sf-003/dynamic/forum_containerOf_post/part-00000-8e2eab71-bd45-48cb-b856-f62243cd1970-c000.csv.split_0
 sf-003/dynamic/forum_containerOf_post/part-00000-8e2eab71-bd45-48cb-b856-f62243cd1970-c000.csv.split_1
 
@@ -42,23 +42,23 @@ creationDate|:START_ID(Forum)|:END_ID(Person)|:TYPE
 sf-003/dynamic/forum_hasMember_person/part-00000-808cfe18-6222-4e80-8eb7-6805821de22e-c000.csv.split_0
 sf-003/dynamic/forum_hasMember_person/part-00000-808cfe18-6222-4e80-8eb7-6805821de22e-c000.csv.split_1
 
-creationDate|:START_ID(Forum)|:END_ID(Person)|:TYPE
+:IGNORE|:START_ID(Forum)|:END_ID(Person)|:TYPE
 sf-003/dynamic/forum_hasModerator_person/part-00000-fb887ce0-a0d5-47c9-b013-ae8aa162462e-c000.csv.split_0
 sf-003/dynamic/forum_hasModerator_person/part-00000-fb887ce0-a0d5-47c9-b013-ae8aa162462e-c000.csv.split_1
 
-creationDate|:START_ID(Forum)|:END_ID(Tag)|:TYPE
+:IGNORE|:START_ID(Forum)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/forum_hasTag_tag/part-00000-99e3e635-b013-4902-aad3-03c456b0d52c-c000.csv.split_0
 sf-003/dynamic/forum_hasTag_tag/part-00000-99e3e635-b013-4902-aad3-03c456b0d52c-c000.csv.split_1
 
-creationDate|:START_ID(Person)|:END_ID(Email)|:TYPE
+:IGNORE|:START_ID(Person)|:END_ID(Email)|:TYPE
 sf-003/dynamic/person_email_emailaddress/manually_transformed_2021_03_04.csv.split_0
 sf-003/dynamic/person_email_emailaddress/manually_transformed_2021_03_04.csv.split_1
 
-creationDate|:START_ID(Person)|:END_ID(Tag)|:TYPE
+:IGNORE|:START_ID(Person)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/person_hasInterest_tag/part-00000-ac53f591-3322-4242-a3fe-fcadbf18cd73-c000.csv.split_0
 sf-003/dynamic/person_hasInterest_tag/part-00000-ac53f591-3322-4242-a3fe-fcadbf18cd73-c000.csv.split_1
 
-creationDate|:START_ID(Person)|:END_ID(Place)|:TYPE
+:IGNORE|:START_ID(Person)|:END_ID(Place)|:TYPE
 sf-003/dynamic/person_isLocatedIn_place/part-00000-1542b788-2a72-4533-8625-cc2806efb2fa-c000.csv.split_0
 sf-003/dynamic/person_isLocatedIn_place/part-00000-1542b788-2a72-4533-8625-cc2806efb2fa-c000.csv.split_1
 
@@ -75,28 +75,28 @@ creationDate|:START_ID(Person)|:END_ID(Post)|:TYPE
 sf-003/dynamic/person_likes_post/part-00000-42cce85f-f27a-40d3-8c65-69f139ffd456-c000.csv.split_0
 sf-003/dynamic/person_likes_post/part-00000-42cce85f-f27a-40d3-8c65-69f139ffd456-c000.csv.split_1
 
-creationDate|:START_ID(Person)|:END_ID(Language)|:TYPE
+:IGNORE|:START_ID(Person)|:END_ID(Language)|:TYPE
 sf-003/dynamic/person_speaks_language/manually_transformed_2021_03_04.csv.split_0
 sf-003/dynamic/person_speaks_language/manually_transformed_2021_03_04.csv.split_1
 
-creationDate|:START_ID(Person)|:END_ID(Organisation)|classYear:LONG|:TYPE
+:IGNORE|:START_ID(Person)|:END_ID(Organisation)|classYear:LONG|:TYPE
 sf-003/dynamic/person_studyAt_organisation/part-00000-2156f71d-0672-4640-bb09-0fae5876122e-c000.csv.split_0
 sf-003/dynamic/person_studyAt_organisation/part-00000-2156f71d-0672-4640-bb09-0fae5876122e-c000.csv.split_1
 
 KATANA_DEFAULT_LABEL=WORK_AT
-creationDate|:START_ID(Person)|:END_ID(Organisation)|workFrom:LONG|:IGNORE
+:IGNORE|:START_ID(Person)|:END_ID(Organisation)|workFrom:LONG|:IGNORE
 sf-003/dynamic/person_workAt_organisation/part-00000-274143b8-ede7-4a41-b8c8-10fea2aa3056-c000.csv.split_0
 sf-003/dynamic/person_workAt_organisation/part-00000-274143b8-ede7-4a41-b8c8-10fea2aa3056-c000.csv.split_1
 
 KATANA_DEFAULT_LABEL=
-creationDate|:START_ID(Post)|:END_ID(Person)|:TYPE
+:IGNORE|:START_ID(Post)|:END_ID(Person)|:TYPE
 sf-003/dynamic/post_hasCreator_person/part-00000-10cb9ef3-dc6c-43e4-b6e7-a2179dcd810c-c000.csv.split_0
 sf-003/dynamic/post_hasCreator_person/part-00000-10cb9ef3-dc6c-43e4-b6e7-a2179dcd810c-c000.csv.split_1
 
-creationDate|:START_ID(Post)|:END_ID(Tag)|:TYPE
+:IGNORE|:START_ID(Post)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/post_hasTag_tag/part-00000-8f918eb1-beed-428f-b68a-18f1c5e3d1d0-c000.csv.split_0
 sf-003/dynamic/post_hasTag_tag/part-00000-8f918eb1-beed-428f-b68a-18f1c5e3d1d0-c000.csv.split_1
 
-creationDate|:START_ID(Post)|:END_ID(Place)|:TYPE
+:IGNORE|:START_ID(Post)|:END_ID(Place)|:TYPE
 sf-003/dynamic/post_isLocatedIn_place/part-00000-d2a7a9ca-9711-48ec-b36d-3089c9a62f09-c000.csv.split_0
 sf-003/dynamic/post_isLocatedIn_place/part-00000-d2a7a9ca-9711-48ec-b36d-3089c9a62f09-c000.csv.split_1

--- a/csv_datasets/ldbc/lists/edges-sf-003-full.txt
+++ b/csv_datasets/ldbc/lists/edges-sf-003-full.txt
@@ -14,27 +14,27 @@ sf-003/static/tag_hasType_tagclass/part-00000-0e79b266-fdeb-45c9-bc07-0df894854d
 sf-003/static/tagclass_isSubclassOf_tagclass/part-00000-3a05ed0e-440f-4389-bdd2-7ecabccdedc7-c000.csv.split_0
 sf-003/static/tagclass_isSubclassOf_tagclass/part-00000-3a05ed0e-440f-4389-bdd2-7ecabccdedc7-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Person)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Person)|:TYPE
 sf-003/dynamic/comment_hasCreator_person/part-00000-6fabcea1-6ec8-4944-a25d-c8af3a1810fd-c000.csv.split_0
 sf-003/dynamic/comment_hasCreator_person/part-00000-6fabcea1-6ec8-4944-a25d-c8af3a1810fd-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Tag)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/comment_hasTag_tag/part-00000-17cded5e-b442-4075-97c9-51eb700574b5-c000.csv.split_0
 sf-003/dynamic/comment_hasTag_tag/part-00000-17cded5e-b442-4075-97c9-51eb700574b5-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Place)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Place)|:TYPE
 sf-003/dynamic/comment_isLocatedIn_place/part-00000-b73c3da6-ab3b-4cc1-b5c1-39914cbb9f71-c000.csv.split_0
 sf-003/dynamic/comment_isLocatedIn_place/part-00000-b73c3da6-ab3b-4cc1-b5c1-39914cbb9f71-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Comment)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Comment)|:TYPE
 sf-003/dynamic/comment_replyOf_comment/part-00000-72df4522-f48d-424c-9d01-11bfe0bc7cea-c000.csv.split_0
 sf-003/dynamic/comment_replyOf_comment/part-00000-72df4522-f48d-424c-9d01-11bfe0bc7cea-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Post)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Post)|:TYPE
 sf-003/dynamic/comment_replyOf_post/part-00000-6bee34cb-0e59-454b-a96f-01bb8c448f42-c000.csv.split_0
 sf-003/dynamic/comment_replyOf_post/part-00000-6bee34cb-0e59-454b-a96f-01bb8c448f42-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Forum)|:END_ID(Post)|:TYPE
+creationDate:IGNORE|:START_ID(Forum)|:END_ID(Post)|:TYPE
 sf-003/dynamic/forum_containerOf_post/part-00000-8e2eab71-bd45-48cb-b856-f62243cd1970-c000.csv.split_0
 sf-003/dynamic/forum_containerOf_post/part-00000-8e2eab71-bd45-48cb-b856-f62243cd1970-c000.csv.split_1
 
@@ -42,23 +42,23 @@ creationDate:DATETIME|:START_ID(Forum)|:END_ID(Person)|:TYPE
 sf-003/dynamic/forum_hasMember_person/part-00000-808cfe18-6222-4e80-8eb7-6805821de22e-c000.csv.split_0
 sf-003/dynamic/forum_hasMember_person/part-00000-808cfe18-6222-4e80-8eb7-6805821de22e-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Forum)|:END_ID(Person)|:TYPE
+creationDate:IGNORE|:START_ID(Forum)|:END_ID(Person)|:TYPE
 sf-003/dynamic/forum_hasModerator_person/part-00000-fb887ce0-a0d5-47c9-b013-ae8aa162462e-c000.csv.split_0
 sf-003/dynamic/forum_hasModerator_person/part-00000-fb887ce0-a0d5-47c9-b013-ae8aa162462e-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Forum)|:END_ID(Tag)|:TYPE
+creationDate:IGNORE|:START_ID(Forum)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/forum_hasTag_tag/part-00000-99e3e635-b013-4902-aad3-03c456b0d52c-c000.csv.split_0
 sf-003/dynamic/forum_hasTag_tag/part-00000-99e3e635-b013-4902-aad3-03c456b0d52c-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Email)|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Email)|:TYPE
 sf-003/dynamic/person_email_emailaddress/manually_transformed_2021_03_04.csv.split_0
 sf-003/dynamic/person_email_emailaddress/manually_transformed_2021_03_04.csv.split_1
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Tag)|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/person_hasInterest_tag/part-00000-ac53f591-3322-4242-a3fe-fcadbf18cd73-c000.csv.split_0
 sf-003/dynamic/person_hasInterest_tag/part-00000-ac53f591-3322-4242-a3fe-fcadbf18cd73-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Place)|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Place)|:TYPE
 sf-003/dynamic/person_isLocatedIn_place/part-00000-1542b788-2a72-4533-8625-cc2806efb2fa-c000.csv.split_0
 sf-003/dynamic/person_isLocatedIn_place/part-00000-1542b788-2a72-4533-8625-cc2806efb2fa-c000.csv.split_1
 
@@ -75,28 +75,28 @@ creationDate:DATETIME|:START_ID(Person)|:END_ID(Post)|:TYPE
 sf-003/dynamic/person_likes_post/part-00000-42cce85f-f27a-40d3-8c65-69f139ffd456-c000.csv.split_0
 sf-003/dynamic/person_likes_post/part-00000-42cce85f-f27a-40d3-8c65-69f139ffd456-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Language)|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Language)|:TYPE
 sf-003/dynamic/person_speaks_language/manually_transformed_2021_03_04.csv.split_0
 sf-003/dynamic/person_speaks_language/manually_transformed_2021_03_04.csv.split_1
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Organisation)|classYear:LONG|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Organisation)|classYear:LONG|:TYPE
 sf-003/dynamic/person_studyAt_organisation/part-00000-2156f71d-0672-4640-bb09-0fae5876122e-c000.csv.split_0
 sf-003/dynamic/person_studyAt_organisation/part-00000-2156f71d-0672-4640-bb09-0fae5876122e-c000.csv.split_1
 
 KATANA_DEFAULT_LABEL=WORK_AT
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Organisation)|workFrom:LONG|:IGNORE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Organisation)|workFrom:LONG|:IGNORE
 sf-003/dynamic/person_workAt_organisation/part-00000-274143b8-ede7-4a41-b8c8-10fea2aa3056-c000.csv.split_0
 sf-003/dynamic/person_workAt_organisation/part-00000-274143b8-ede7-4a41-b8c8-10fea2aa3056-c000.csv.split_1
 
 KATANA_DEFAULT_LABEL=
-creationDate:DATETIME|:START_ID(Post)|:END_ID(Person)|:TYPE
+creationDate:IGNORE|:START_ID(Post)|:END_ID(Person)|:TYPE
 sf-003/dynamic/post_hasCreator_person/part-00000-10cb9ef3-dc6c-43e4-b6e7-a2179dcd810c-c000.csv.split_0
 sf-003/dynamic/post_hasCreator_person/part-00000-10cb9ef3-dc6c-43e4-b6e7-a2179dcd810c-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Post)|:END_ID(Tag)|:TYPE
+creationDate:IGNORE|:START_ID(Post)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/post_hasTag_tag/part-00000-8f918eb1-beed-428f-b68a-18f1c5e3d1d0-c000.csv.split_0
 sf-003/dynamic/post_hasTag_tag/part-00000-8f918eb1-beed-428f-b68a-18f1c5e3d1d0-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Post)|:END_ID(Place)|:TYPE
+creationDate:IGNORE|:START_ID(Post)|:END_ID(Place)|:TYPE
 sf-003/dynamic/post_isLocatedIn_place/part-00000-d2a7a9ca-9711-48ec-b36d-3089c9a62f09-c000.csv.split_0
 sf-003/dynamic/post_isLocatedIn_place/part-00000-d2a7a9ca-9711-48ec-b36d-3089c9a62f09-c000.csv.split_1

--- a/csv_datasets/ldbc/lists/edges-sf-003-half_000.txt
+++ b/csv_datasets/ldbc/lists/edges-sf-003-half_000.txt
@@ -10,40 +10,40 @@ sf-003/static/tag_hasType_tagclass/part-00000-0e79b266-fdeb-45c9-bc07-0df894854d
 :START_ID(TagClass)|:END_ID(TagClass)|:TYPE
 sf-003/static/tagclass_isSubclassOf_tagclass/part-00000-3a05ed0e-440f-4389-bdd2-7ecabccdedc7-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Person)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Person)|:TYPE
 sf-003/dynamic/comment_hasCreator_person/part-00000-6fabcea1-6ec8-4944-a25d-c8af3a1810fd-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Tag)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/comment_hasTag_tag/part-00000-17cded5e-b442-4075-97c9-51eb700574b5-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Place)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Place)|:TYPE
 sf-003/dynamic/comment_isLocatedIn_place/part-00000-b73c3da6-ab3b-4cc1-b5c1-39914cbb9f71-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Comment)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Comment)|:TYPE
 sf-003/dynamic/comment_replyOf_comment/part-00000-72df4522-f48d-424c-9d01-11bfe0bc7cea-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Post)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Post)|:TYPE
 sf-003/dynamic/comment_replyOf_post/part-00000-6bee34cb-0e59-454b-a96f-01bb8c448f42-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Forum)|:END_ID(Post)|:TYPE
+creationDate:IGNORE|:START_ID(Forum)|:END_ID(Post)|:TYPE
 sf-003/dynamic/forum_containerOf_post/part-00000-8e2eab71-bd45-48cb-b856-f62243cd1970-c000.csv.split_0
 
 creationDate:DATETIME|:START_ID(Forum)|:END_ID(Person)|:TYPE
 sf-003/dynamic/forum_hasMember_person/part-00000-808cfe18-6222-4e80-8eb7-6805821de22e-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Forum)|:END_ID(Person)|:TYPE
+creationDate:IGNORE|:START_ID(Forum)|:END_ID(Person)|:TYPE
 sf-003/dynamic/forum_hasModerator_person/part-00000-fb887ce0-a0d5-47c9-b013-ae8aa162462e-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Forum)|:END_ID(Tag)|:TYPE
+creationDate:IGNORE|:START_ID(Forum)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/forum_hasTag_tag/part-00000-99e3e635-b013-4902-aad3-03c456b0d52c-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Email)|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Email)|:TYPE
 sf-003/dynamic/person_email_emailaddress/manually_transformed_2021_03_04.csv.split_0
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Tag)|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/person_hasInterest_tag/part-00000-ac53f591-3322-4242-a3fe-fcadbf18cd73-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Place)|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Place)|:TYPE
 sf-003/dynamic/person_isLocatedIn_place/part-00000-1542b788-2a72-4533-8625-cc2806efb2fa-c000.csv.split_0
 
 creationDate:DATETIME|:START_ID(Person)|:END_ID(Person)|:TYPE
@@ -57,17 +57,17 @@ sf-003/dynamic/person_knows_person/part-00000-ca1e15f9-6b36-4e63-a024-24c0391e66
 creationDate:DATETIME|:START_ID(Person)|:END_ID(Post)|:TYPE
 sf-003/dynamic/person_likes_post/part-00000-42cce85f-f27a-40d3-8c65-69f139ffd456-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Language)|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Language)|:TYPE
 sf-003/dynamic/person_speaks_language/manually_transformed_2021_03_04.csv.split_0
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Organisation)|classYear:LONG|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Organisation)|classYear:LONG|:TYPE
 sf-003/dynamic/person_studyAt_organisation/part-00000-2156f71d-0672-4640-bb09-0fae5876122e-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Post)|:END_ID(Person)|:TYPE
+creationDate:IGNORE|:START_ID(Post)|:END_ID(Person)|:TYPE
 sf-003/dynamic/post_hasCreator_person/part-00000-10cb9ef3-dc6c-43e4-b6e7-a2179dcd810c-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Post)|:END_ID(Tag)|:TYPE
+creationDate:IGNORE|:START_ID(Post)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/post_hasTag_tag/part-00000-8f918eb1-beed-428f-b68a-18f1c5e3d1d0-c000.csv.split_0
 
-creationDate:DATETIME|:START_ID(Post)|:END_ID(Place)|:TYPE
+creationDate:IGNORE|:START_ID(Post)|:END_ID(Place)|:TYPE
 sf-003/dynamic/post_isLocatedIn_place/part-00000-d2a7a9ca-9711-48ec-b36d-3089c9a62f09-c000.csv.split_0

--- a/csv_datasets/ldbc/lists/edges-sf-003-half_001.txt
+++ b/csv_datasets/ldbc/lists/edges-sf-003-half_001.txt
@@ -10,40 +10,40 @@ sf-003/static/tag_hasType_tagclass/part-00000-0e79b266-fdeb-45c9-bc07-0df894854d
 :START_ID(TagClass)|:END_ID(TagClass)|:TYPE
 sf-003/static/tagclass_isSubclassOf_tagclass/part-00000-3a05ed0e-440f-4389-bdd2-7ecabccdedc7-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Person)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Person)|:TYPE
 sf-003/dynamic/comment_hasCreator_person/part-00000-6fabcea1-6ec8-4944-a25d-c8af3a1810fd-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Tag)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/comment_hasTag_tag/part-00000-17cded5e-b442-4075-97c9-51eb700574b5-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Place)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Place)|:TYPE
 sf-003/dynamic/comment_isLocatedIn_place/part-00000-b73c3da6-ab3b-4cc1-b5c1-39914cbb9f71-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Comment)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Comment)|:TYPE
 sf-003/dynamic/comment_replyOf_comment/part-00000-72df4522-f48d-424c-9d01-11bfe0bc7cea-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Comment)|:END_ID(Post)|:TYPE
+creationDate:IGNORE|:START_ID(Comment)|:END_ID(Post)|:TYPE
 sf-003/dynamic/comment_replyOf_post/part-00000-6bee34cb-0e59-454b-a96f-01bb8c448f42-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Forum)|:END_ID(Post)|:TYPE
+creationDate:IGNORE|:START_ID(Forum)|:END_ID(Post)|:TYPE
 sf-003/dynamic/forum_containerOf_post/part-00000-8e2eab71-bd45-48cb-b856-f62243cd1970-c000.csv.split_1
 
 creationDate:DATETIME|:START_ID(Forum)|:END_ID(Person)|:TYPE
 sf-003/dynamic/forum_hasMember_person/part-00000-808cfe18-6222-4e80-8eb7-6805821de22e-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Forum)|:END_ID(Person)|:TYPE
+creationDate:IGNORE|:START_ID(Forum)|:END_ID(Person)|:TYPE
 sf-003/dynamic/forum_hasModerator_person/part-00000-fb887ce0-a0d5-47c9-b013-ae8aa162462e-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Forum)|:END_ID(Tag)|:TYPE
+creationDate:IGNORE|:START_ID(Forum)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/forum_hasTag_tag/part-00000-99e3e635-b013-4902-aad3-03c456b0d52c-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Email)|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Email)|:TYPE
 sf-003/dynamic/person_email_emailaddress/manually_transformed_2021_03_04.csv.split_1
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Tag)|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/person_hasInterest_tag/part-00000-ac53f591-3322-4242-a3fe-fcadbf18cd73-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Place)|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Place)|:TYPE
 sf-003/dynamic/person_isLocatedIn_place/part-00000-1542b788-2a72-4533-8625-cc2806efb2fa-c000.csv.split_1
 
 creationDate:DATETIME|:START_ID(Person)|:END_ID(Person)|:TYPE
@@ -52,23 +52,23 @@ sf-003/dynamic/person_knows_person/part-00000-ca1e15f9-6b36-4e63-a024-24c0391e66
 creationDate:DATETIME|:START_ID(Person)|:END_ID(Post)|:TYPE
 sf-003/dynamic/person_likes_post/part-00000-42cce85f-f27a-40d3-8c65-69f139ffd456-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Language)|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Language)|:TYPE
 sf-003/dynamic/person_speaks_language/manually_transformed_2021_03_04.csv.split_1
 
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Organisation)|classYear:LONG|:TYPE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Organisation)|classYear:LONG|:TYPE
 sf-003/dynamic/person_studyAt_organisation/part-00000-2156f71d-0672-4640-bb09-0fae5876122e-c000.csv.split_1
 
 KATANA_DEFAULT_LABEL=WORK_AT
-creationDate:DATETIME|:START_ID(Person)|:END_ID(Organisation)|workFrom:LONG|:IGNORE
+creationDate:IGNORE|:START_ID(Person)|:END_ID(Organisation)|workFrom:LONG|:IGNORE
 sf-003/dynamic/person_workAt_organisation/part-00000-274143b8-ede7-4a41-b8c8-10fea2aa3056-c000.csv.split_0
 sf-003/dynamic/person_workAt_organisation/part-00000-274143b8-ede7-4a41-b8c8-10fea2aa3056-c000.csv.split_1
 
 KATANA_DEFAULT_LABEL=
-creationDate:DATETIME|:START_ID(Post)|:END_ID(Person)|:TYPE
+creationDate:IGNORE|:START_ID(Post)|:END_ID(Person)|:TYPE
 sf-003/dynamic/post_hasCreator_person/part-00000-10cb9ef3-dc6c-43e4-b6e7-a2179dcd810c-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Post)|:END_ID(Tag)|:TYPE
+creationDate:IGNORE|:START_ID(Post)|:END_ID(Tag)|:TYPE
 sf-003/dynamic/post_hasTag_tag/part-00000-8f918eb1-beed-428f-b68a-18f1c5e3d1d0-c000.csv.split_1
 
-creationDate:DATETIME|:START_ID(Post)|:END_ID(Place)|:TYPE
+creationDate:IGNORE|:START_ID(Post)|:END_ID(Place)|:TYPE
 sf-003/dynamic/post_isLocatedIn_place/part-00000-d2a7a9ca-9711-48ec-b36d-3089c9a62f09-c000.csv.split_1

--- a/csv_datasets/ldbc/lists/edges-sf-003-parquet-string-type.txt
+++ b/csv_datasets/ldbc/lists/edges-sf-003-parquet-string-type.txt
@@ -38,7 +38,7 @@ creationDate:IGNORE|:START_ID(Forum)|:END_ID(Post)
 sf-003/parquet/9/part.0.parquet
 sf-003/parquet/9/part.1.parquet
 
-creationDate:IGNORE|:START_ID(Forum)|:END_ID(Person)
+creationDate:DATETIME|:START_ID(Forum)|:END_ID(Person)
 sf-003/parquet/10/part.0.parquet
 sf-003/parquet/10/part.1.parquet
 
@@ -63,12 +63,12 @@ sf-003/parquet/15/part.0.parquet
 sf-003/parquet/15/part.1.parquet
 
 KATANA_DEFAULT_LABEL=KNOWS
-creationDate:IGNORE|:START_ID(Person)|:END_ID(Person)
+creationDate:DATETIME|:START_ID(Person)|:END_ID(Person)
 sf-003/parquet/16/part.0.parquet
 sf-003/parquet/16/part.1.parquet
 
 KATANA_DEFAULT_LABEL=
-creationDate:IGNORE|:START_ID(Person)|:END_ID(Post)
+creationDate:DATETIME|:START_ID(Person)|:END_ID(Post)
 sf-003/parquet/21/part.0.parquet
 sf-003/parquet/21/part.1.parquet
 

--- a/csv_datasets/ldbc/lists/nodes-sf-003-full-parquet.txt
+++ b/csv_datasets/ldbc/lists/nodes-sf-003-full-parquet.txt
@@ -14,19 +14,19 @@ id:ID(TagClass)|name:STRING|url:STRING
 sf-003/parquet/31/part.0.parquet
 sf-003/parquet/31/part.1.parquet
 
-creationDate:IGNORE|id:ID(Comment)|locationIP:STRING|browserUsed:STRING|content:STRING|length:LONG
+creationDate:DATETIME|id:ID(Comment)|locationIP:STRING|browserUsed:STRING|content:STRING|length:LONG
 sf-003/parquet/32/part.0.parquet
 sf-003/parquet/32/part.1.parquet
 
-creationDate:IGNORE|id:ID(Forum)|title:STRING
+creationDate:DATETIME|id:ID(Forum)|title:STRING
 sf-003/parquet/33/part.0.parquet
 sf-003/parquet/33/part.1.parquet
 
-creationDate:IGNORE|id:ID(Person)|firstName:STRING|lastName:STRING|gender:STRING|birthday:IGNORE|locationIP:STRING|browserUsed:STRING
+creationDate:DATETIME|id:ID(Person)|firstName:STRING|lastName:STRING|gender:STRING|birthday:IGNORE|locationIP:STRING|browserUsed:STRING
 sf-003/parquet/34/part.0.parquet
 sf-003/parquet/34/part.1.parquet
 
-creationDate:IGNORE|id:ID(Post)|imageFile:STRING|locationIP:STRING|browserUsed:STRING|language:STRING|content:STRING|length:LONG|forumID:IGNORE
+creationDate:DATETIME|id:ID(Post)|imageFile:STRING|locationIP:STRING|browserUsed:STRING|language:STRING|content:STRING|length:LONG|forumID:IGNORE
 sf-003/parquet/35/part.0.parquet
 sf-003/parquet/35/part.1.parquet
 

--- a/csv_datasets/ldbc/lists/nodes-sf-003-parquet-string-type.txt
+++ b/csv_datasets/ldbc/lists/nodes-sf-003-parquet-string-type.txt
@@ -14,19 +14,19 @@ id:ID(TagClass)|name:STRING|url:STRING
 sf-003/parquet/31/part.0.parquet
 sf-003/parquet/31/part.1.parquet
 
-creationDate:IGNORE|id:ID(Comment)|locationIP:STRING|browserUsed:STRING|content:STRING|length:STRING
+creationDate:DATETIME|id:ID(Comment)|locationIP:STRING|browserUsed:STRING|content:STRING|length:STRING
 sf-003/parquet/32/part.0.parquet
 sf-003/parquet/32/part.1.parquet
 
-creationDate:IGNORE|id:ID(Forum)|title:STRING
+creationDate:DATETIME|id:ID(Forum)|title:STRING
 sf-003/parquet/33/part.0.parquet
 sf-003/parquet/33/part.1.parquet
 
-creationDate:STRING|id:ID(Person)|firstName:STRING|lastName:STRING|gender:STRING|birthday:STRING|locationIP:STRING|browserUsed:STRING
+creationDate:DATETIME|id:ID(Person)|firstName:STRING|lastName:STRING|gender:STRING|birthday:STRING|locationIP:STRING|browserUsed:STRING
 sf-003/parquet/34/part.0.parquet
 sf-003/parquet/34/part.1.parquet
 
-creationDate:IGNORE|id:ID(Post)|imageFile:STRING|locationIP:STRING|browserUsed:STRING|language:STRING|content:STRING|length:STRING|forumID:STRING
+creationDate:DATETIME|id:ID(Post)|imageFile:STRING|locationIP:STRING|browserUsed:STRING|language:STRING|content:STRING|length:STRING|forumID:IGNORE
 sf-003/parquet/35/part.0.parquet
 sf-003/parquet/35/part.1.parquet
 


### PR DESCRIPTION
jira: KAT-5298
As it exists now, the schema used to generate our katana RDGs do not match those in the official spec (link mentioned below). This is because the CSV data generated by the LDBC generator which is used to generate our RDGs contains some additional data (when compared to the official spec), which should ideally be ignored when generating our RDGs. 
This PR edits the schema lists we use to generate our LDBC RDG datasets, so that the data may be regenerated according to the official spec. 
As a side-note, in the future, once we have a way to convert DATETIME to string, we should change the type for all the creationDate(s) in the parquet-string-type datasets to string
This could really use a second pair of eyes, double checking the changes made in the lists and comparing them to the spec here on pg 16 https://ldbcouncil.org/ldbc_snb_docs/ldbc-snb-specification.pdf