### PR TITLE
Create generic pythonscript rdg_generate function

### DIFF
--- a/libuprev/constants.py
+++ b/libuprev/constants.py
@@ -4,4 +4,5 @@ TOOLS = {
     "uprev-rdg-storage-format-version-worker": "external/katana/tools/uprev-rdg-storage-format-version-worker/uprev-rdg-storage-format-version-worker",
     "partition-dist": "lonestar/analytics/distributed/partition/partition-dist",
     "csv-import": "tools/import/csv-import",
+    "katana_enterprise_python" : "katana_enterprise_python_build",
 }

--- a/libuprev/rdg_generate.py
+++ b/libuprev/rdg_generate.py
@@ -68,3 +68,44 @@ def generate_partition_dist_tool(
     env["AWS_EC2_METADATA_DISABLED"] = str(aws_disabled)
 
     subprocess.run(cmd, check=True, env=env)
+
+
+# call a custom script from the katana enterprise repo
+# if out_path is None, the tool works in-place on the in_path
+def generate_python_enterprise_tool(config: Config,
+                                            in_path: pathlib.Path,
+                                            out_path: pathlib.Path,
+                                            python_script_path: pathlib.Path,
+                                            generate_args: list[str],
+                                            aws_disabled: bool = True,
+):
+    tool_name = "katana_enterprise_python"
+    tool_path = config.build_dir / constants.TOOLS.get(tool_name, None)
+
+    # path to the built Katana python environment
+    python_env_path = config.build_dir / "python_env.sh"
+
+    fs.ensure_dir("build", config.build_dir)
+    fs.ensure_file("python env script", python_env_path, "have you built the python library? Run 'make {}' in {}".format(tool_name, config.build_dir) )
+    fs.ensure_file(
+        "python tool script", python_script_path, "have you built it?. Run 'make {}' in {}".format(tool_name, config.build_dir)
+    )
+
+
+    return_path = out_path
+    if out_path == None:
+        out_path = ""
+        return_path = in_path
+
+    # create command in the form "python_env.sh python3 <script-path> <input-rdg-dir> <output-rdg-dir> <additional-args>"
+    cmd = (
+        [python_env_path, "python3", python_script_path, in_path, out_path]
+        + generate_args
+    )
+
+    env = os.environ.copy()
+    env["AWS_EC2_METADATA_DISABLED"] = str(aws_disabled)
+
+    subprocess.run(cmd, check=True, env=env)
+
+    return return_path

--- a/rdg_datasets/many_self_loops_w_sink_ai/generate.py
+++ b/rdg_datasets/many_self_loops_w_sink_ai/generate.py
@@ -3,7 +3,7 @@ import pathlib
 import subprocess
 
 import csv_datasets
-from libuprev import rdg_import
+from libuprev import rdg_import, constants, rdg_generate
 from libuprev.uprev_config import Config
 
 local_path = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
@@ -30,16 +30,12 @@ def uprev(config: Config, new_storage_format_version: int) -> pathlib.Path:
         import_args=import_args,
     )
 
-    # path to the built Katana python environment
-    python_env_path = config.build_dir / "python_env.sh"
     # path to feature adding script in an enterprise build
     script_path = (
-        config.build_dir / "katana_enterprise_python_build/python/test/datagen/many_self_loops_w_sink_ai_features.py"
+        config.build_dir / constants.TOOLS.get("katana_enterprise_python", None) / "python/test/datagen/many_self_loops_w_sink_ai_features.py"
     )
 
-    # run script to add features to the RDG (in-place)
-    cmd = [python_env_path, "python3", script_path, return_path.absolute()]
-    subprocess.run(cmd, check=True)
-
-    # returns the original path as required by uprev
-    return return_path
+    return rdg_generate.generate_python_enterprise_tool(config=config,
+                                                        in_path=return_path,
+                                                        out_path=None,
+                                                        python_script_path=script_path, generate_args=[])

--- a/rdg_datasets/two_self_loops_ai/generate.py
+++ b/rdg_datasets/two_self_loops_ai/generate.py
@@ -3,7 +3,7 @@ import pathlib
 import subprocess
 
 import csv_datasets
-from libuprev import rdg_import
+from libuprev import rdg_import, constants, rdg_generate
 from libuprev.uprev_config import Config
 
 local_path = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
@@ -30,16 +30,12 @@ def uprev(config: Config, new_storage_format_version: int) -> pathlib.Path:
         import_args=import_args,
     )
 
-    # path to the built Katana python environment
-    python_env_path = config.build_dir / "python_env.sh"
     # path to feature adding script in an enterprise build
     script_path = (
-        config.build_dir / "katana_enterprise_python_build/python/test/datagen/two_self_loops_ai_features.py"
+        config.build_dir / constants.TOOLS.get("katana_enterprise_python", None) / "python/test/datagen/two_self_loops_ai_features.py"
     )
 
-    # run script to add features to the RDG (in-place)
-    cmd = [python_env_path, "python3", script_path, return_path.absolute()]
-    subprocess.run(cmd, check=True)
-
-    # returns the original path as required by uprev
-    return return_path
+    return rdg_generate.generate_python_enterprise_tool(config=config,
+                                                        in_path=return_path,
+                                                        out_path=None,
+                                                        python_script_path=script_path, generate_args=[])


### PR DESCRIPTION
### PR Checklist

<!-- Please read README.md before submitting your pull request -->
* [* ] test-datasets is a publicly accessible github repo. The contents of this PR can be made public.
* [ *] The naming and organization of the dataset I am adding follows https://github.com/KatanaGraph/test-datasets#organization
* [ *] If I am adding an RDG, its directory contains a (import/migrate/generate) script, and a README describing the RDGs usage. https://github.com/KatanaGraph/test-datasets#the-following-scripts-are-conditionally-present-for-each-rdg-one-of-the-following-options-must-be-present
* [ *] If I am uprevving the storage_format_version of the rdgs in this repo, I have followed https://github.com/KatanaGraph/test-datasets#how-to-uprev-the-rdgs-in-this-repo


### List of folks that should be notified of this PR. Please don't remove these. 
@e-mcginnis
@aneeshdurg

<!-- Put your PR content below here -->

Add a generic rdg_generate function to run scripts which use the katana python api
And `uprev build_tools` will now build the katana python api