### PR TITLE
replace katana_enterprise with katana

### DIFF
--- a/rdg_datasets/arxiv_100_v1/README.md
+++ b/rdg_datasets/arxiv_100_v1/README.md
@@ -1,7 +1,7 @@
 arxiv_100 is a small graph which has a fixedsizebinary vector feature for use in testing similarity graph construction.
 It is extracted from the arxiv dataset that can be loaded/copied with:
 
-python -m katana_enterprise.ai.data.ogb_datasets --dataset arxiv
+python -m katana.ai.data.ogb_datasets --dataset arxiv
 
 Then running the following queries on the resulting graph:
 


### PR DESCRIPTION
@scober
@aneeshdurg

`katana_enterprise` no longer exists as a python package. Instead everything is in `katana`. There was a reference to the old name in the docs here.